### PR TITLE
fix docker-compose file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,18 +2,26 @@ version: "3.9"
 services:
   app:
     image: docker
+    build:
+      context: .
+      dockerfile: Dockerfile
     environment:
-      POSTGRES_USER: jp
-      POSTGRES_PASSWD: 123456
-      POSTGRES_HOST: localhost
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWD: "123456"
+      POSTGRES_HOST: db
       POSTGRES_PORT: 5432
     ports:
       - 3000:3000
     depends_on:
       - db
   db:
-    image: postgres:14.5-alpine
+    image: postgres:14.5
     ports:
       - 5432:5432
     environment:
-      POSTGRES_PASSWORD: 123456
+      POSTGRES_PASSWORD: "123456"
+    volumes:
+      - db:/var/lib/postgresql/data
+
+volumes:
+  db:


### PR DESCRIPTION
Agora depois de clonar o projeto é necessário ter docker e docker compose instalados.
Primeiro é necessário dar um `docker compose up app` depois que tudo inicializar pode fechar o container e rodar um `docker compose run app sh`, dentro do container é necessário rodar o `rails db:create` e `rails db:migrate`. Após isso é só subir o app de novo que vai dar certo: `docker compose up app`
Ainda é necessário arrumar o dockerfile para instalar as outras coisas do vue, vou fazer isso em outro PR